### PR TITLE
fix typos, make guitar vid link open in new tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@
             In my free time I enjoy a variety of hobbies including lockpicking, climbing, Spikeball, and guitar. I also
             enjoy playing
             video games to connect with friends who have moved away and can't be met in person. I also have developed a
-            passion cooking
+            passion for cooking
             (although I need practice) and am an avid 49ers football fan.
           </p>
 
@@ -74,7 +74,7 @@
               <li><span>Project Management</span><br>Project manager for capstone design, responsible for Gantt chart in
                 MS Project, alocating tasks to team, and coordinating with the sponsor, Medtronic</li>
               <li><span>Sustainable Manufacturing</span><br>A firm understanding of manufacturing processes learned
-                through both school cariculum and internships</li>
+                through both school currriculum and internships</li>
             </ul>
           </div>
           <div class="tab-contents" id="experience">
@@ -178,7 +178,7 @@
               you to my YouTube channel where I’ve posted to showcase my ability. While classical guitar is inherently a
               challenging skill in itself to learn, I would argue the more impressive feat is the time dedicated.<br>See
               video attached. </p>
-            <a href="https://youtu.be/hcvS74nFTdY"><i class="fa-solid fa-up-right-from-square"></i></a>
+            <a target="_blank" href="https://youtu.be/hcvS74nFTdY"><i class="fa-solid fa-up-right-from-square"></i></a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Just fixed a couple typos i saw, and made it so the link icon for the guitar vid in the projects section opens in a new tab. 